### PR TITLE
feat: add support for basic lighting renderer

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -228,6 +228,8 @@ func buildMap(config *carto.Config, opts BuildOpts, mapCfg *carto.MapConfigBlock
 			chunkRenderer = carto.NewChunkPixelRenderer(renderOpts, assetLoader)
 		} else if layerCfg.Render == "biome" {
 			chunkRenderer = carto.NewBiomeRenderer(assetLoader)
+		} else if layerCfg.Render == "light" {
+			chunkRenderer = carto.NewLightingRenderer()
 		} else {
 			log.Panicf("Unsupported renderer '%s'", layerCfg.Render)
 		}

--- a/chunk.go
+++ b/chunk.go
@@ -1,0 +1,13 @@
+package carto
+
+import (
+	"image"
+
+	"github.com/Tnze/go-mc/save"
+)
+
+type ChunkRenderer interface {
+	ImageSize() (int, int)
+	RenderChunk(*save.Chunk) (image.Image, error)
+	Finalize(path string) error
+}

--- a/example.config.hcl
+++ b/example.config.hcl
@@ -14,15 +14,19 @@ layer "biome" {
   opacity = 0.5
 }
 
+layer "light" {
+  render = "light"
+}
+
 map "overworld" {
   output = "web"
   path   = "/home/andrei/mc/world/region"
-  layers = ["normal", "biome"]
+  layers = ["normal", "biome", "light"]
 }
 
 map "hermitcraft9" {
   output  = "web"
   path    = "/mnt/bigdata/mc/tmp/region"
-  layers  = ["normal", "biome"]
+  layers  = ["normal", "biome", "light"]
   version = "1.20.1"
 }

--- a/lighting.go
+++ b/lighting.go
@@ -1,0 +1,64 @@
+package carto
+
+import (
+	"image"
+	"image/color"
+	"math/bits"
+
+	"github.com/Tnze/go-mc/level"
+	"github.com/Tnze/go-mc/save"
+)
+
+type LightingRenderer struct {
+}
+
+func NewLightingRenderer() *LightingRenderer {
+	return &LightingRenderer{}
+}
+
+func (c *LightingRenderer) Finalize(path string) error {
+	return nil
+}
+
+func (c *LightingRenderer) ImageSize() (int, int) {
+	return 16, 16
+}
+
+func (c *LightingRenderer) RenderChunk(chunk *save.Chunk) (image.Image, error) {
+	img := image.NewRGBA64(image.Rect(0, 0, 16, 16))
+	bitsForHeight := bits.Len(uint(len(chunk.Sections))*16 + 1)
+	motionBlocking := level.NewBitStorage(bitsForHeight, 16*16, chunk.Heightmaps["MOTION_BLOCKING"])
+
+	for x := 0; x < 16; x++ {
+		for z := 0; z < 16; z++ {
+			heightmapIndex := ((z) * 16) + x
+			yStart := motionBlocking.Get(heightmapIndex)
+			sectionY := yStart / 16
+
+			section := chunk.Sections[sectionY]
+
+			blockLight := byte(0)
+			if len(section.BlockLight) > 0 {
+				blockLightIndex := x + ((sectionY & 0x0f) << 8) + (z << 4)
+				blockLightRaw := section.BlockLight[blockLightIndex/2]
+
+				if blockLightIndex&1 > 0 {
+					blockLight = (blockLightRaw >> 4) & 0x0F
+				} else {
+					blockLight = (blockLightRaw & 0x0F)
+				}
+
+			}
+
+			a := 192 - ((blockLight + 1) * 12)
+			img.Set(x, z, color.RGBA{
+				R: 0,
+				G: 0,
+				B: 0,
+				A: a,
+			})
+		}
+	}
+
+	return img, nil
+}

--- a/palette.go
+++ b/palette.go
@@ -20,6 +20,7 @@ var airBlocks = map[string]struct{}{
 	"minecraft:short_grass": {},
 	"minecraft:lily_pad":    {},
 	"minecraft:torch":       {},
+	"minecraft:wall_torch":  {},
 }
 
 func isAirBlock(block string) bool {

--- a/palette.go
+++ b/palette.go
@@ -19,6 +19,7 @@ var airBlocks = map[string]struct{}{
 	"minecraft:dead_bush":   {},
 	"minecraft:short_grass": {},
 	"minecraft:lily_pad":    {},
+	"minecraft:torch":       {},
 }
 
 func isAirBlock(block string) bool {

--- a/pixel.go
+++ b/pixel.go
@@ -10,12 +10,6 @@ import (
 	"github.com/Tnze/go-mc/save"
 )
 
-type ChunkRenderer interface {
-	ImageSize() (int, int)
-	RenderChunk(*save.Chunk) (image.Image, error)
-	Finalize(path string) error
-}
-
 type ChunkPixelRendererOpts struct {
 	Shading bool
 }


### PR DESCRIPTION
This pr adds support for generating lighting based layers which utilize each blocks calculated (and cached) light-level to provide a night-like view of the world.

## example

![image](https://github.com/b1naryth1ef/carto/assets/599433/5145645a-7004-48bb-aff4-f67f645607c8)
