### PR TITLE
feat: add 'strip-ceiling' option for rendering nether region

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -220,12 +220,11 @@ func buildMap(config *carto.Config, opts BuildOpts, mapCfg *carto.MapConfigBlock
 			}
 		}
 
+		opts := carto.NewChunkRenderOpts(layerCfg.Options)
+
 		var chunkRenderer carto.ChunkRenderer
 		if layerCfg.Render == "pixel" {
-			renderOpts := carto.ChunkPixelRendererOpts{
-				Shading: true,
-			}
-			chunkRenderer = carto.NewChunkPixelRenderer(renderOpts, assetLoader)
+			chunkRenderer = carto.NewChunkPixelRenderer(opts, assetLoader)
 		} else if layerCfg.Render == "biome" {
 			chunkRenderer = carto.NewBiomeRenderer(assetLoader)
 		} else if layerCfg.Render == "light" {

--- a/chunk.go
+++ b/chunk.go
@@ -11,3 +11,24 @@ type ChunkRenderer interface {
 	RenderChunk(*save.Chunk) (image.Image, error)
 	Finalize(path string) error
 }
+
+type ChunkRenderOpts struct {
+	data map[string]string
+}
+
+func NewChunkRenderOpts(data map[string]string) *ChunkRenderOpts {
+	return &ChunkRenderOpts{data: data}
+}
+
+func (c *ChunkRenderOpts) GetBool(key string, def bool) bool {
+	v, ok := c.data[key]
+	if !ok {
+		return def
+	}
+
+	if v == "true" || v == "1" {
+		return true
+	}
+
+	return false
+}

--- a/config.go
+++ b/config.go
@@ -21,9 +21,10 @@ type OutputConfigBlock struct {
 }
 
 type LayerConfigBlock struct {
-	Name    string  `hcl:"name,label"`
-	Render  string  `hcl:"render"`
-	Opacity float64 `hcl:"opacity,optional"`
+	Name    string            `hcl:"name,label"`
+	Render  string            `hcl:"render"`
+	Opacity float64           `hcl:"opacity,optional"`
+	Options map[string]string `hcl:"options,optional"`
 }
 
 type MapConfigBlock struct {


### PR DESCRIPTION
This pr adds the ability to define custom options per-renderer and additionally adds support for the `strip-ceiling` option in the pixel renderer. This option can be used for rendering the nether region. For now one downside of this is that it will break pixel-shading but this can be fixed in the future when the shader rendering is broken out to its own renderer layer.

![image](https://github.com/b1naryth1ef/carto/assets/599433/cc776a9d-c10e-4745-b87b-1581f96b848a)
